### PR TITLE
Display interval in buttons

### DIFF
--- a/src/components/Crow.vue
+++ b/src/components/Crow.vue
@@ -29,26 +29,22 @@
                 label-for="input-date"
                 description="Charts will be centered on noon for selected date."
               >
-                
-
-                <b-input-group>
+                <b-input-group size="sm">
                   <b-input-group-prepend>
-                    <b-button size="sm" v-on:click="decrementPeriod">&lt;&lt;</b-button>
+                    <b-button variant="outline-secondary" v-on:click="decrementPeriod">-{{ selectedIntervalInHours }}h</b-button>
                   </b-input-group-prepend>
 
                   <b-form-input
-                  id="input-date"
-                  size="sm"
-                  type="date"
-                  placeholder="Type a date..."
-                  v-model="selectedDate"
+                    id="input-date"
+                    type="date"
+                    placeholder="Type a date..."
+                    v-model="selectedDate"
                   />
 
                   <b-input-group-append>
-                    <b-button size="sm" v-on:click="incrementPeriod">&gt;&gt;</b-button>
+                    <b-button variant="outline-secondary" v-on:click="incrementPeriod">+{{ selectedIntervalInHours }}h</b-button>
                   </b-input-group-append>
                 </b-input-group>
-
               </b-form-group>
             </b-col>
           </b-row>


### PR DESCRIPTION
@niconoe see #55. Navigation buttons now explicitly display interval:

<img width="361" alt="Screenshot 2020-02-03 at 11 03 53" src="https://user-images.githubusercontent.com/600993/73644399-9c8fa900-4675-11ea-9f18-fcf0e1ddfe32.png">

Which I think works well. Two todos for you:

- Actually increase period with the selectedInterval
- Display selectedInterval in days (not hours) on buttons