### PR TITLE
Fix failing tests (#188)

### DIFF
--- a/src/components/Home.vue
+++ b/src/components/Home.vue
@@ -357,7 +357,7 @@ export default Vue.extend({
       get: function (): string {
         return UserChoicesStoreModule.selectedDate;
       },
-      set: function (newValue: string) {
+      set: function (newValue: string): void {
         UserChoicesStoreModule.setSelectedDate(newValue);
       }
     },
@@ -366,7 +366,7 @@ export default Vue.extend({
       get: function (): TimeDisplayedAsValue {
         return UserChoicesStoreModule.timeDisplayedAs;
       },
-      set: function (newValue: TimeDisplayedAsValue) {
+      set: function (newValue: TimeDisplayedAsValue): void {
         UserChoicesStoreModule.setTimeDisplayedAs(newValue);
       }
     },
@@ -375,7 +375,7 @@ export default Vue.extend({
       get: function (): number {
         return UserChoicesStoreModule.selectedIntervalInHours;
       },
-      set: function (newValue: number) {
+      set: function (newValue: number): void {
         UserChoicesStoreModule.setSelectedIntervalInHours(newValue);
       }
     },
@@ -491,7 +491,7 @@ export default Vue.extend({
     this.baseUrl = this.trimLastSlash(window.location.origin);
   },
   methods: {
-    t(stringId: string) {
+    t(stringId: string): string {
       return helpers.translateString(stringId, this.selectedLanguageCode, this.texts);
     },
     chooseAppLanguage() : LangCode {

--- a/tests/unit/crow.spec.ts
+++ b/tests/unit/crow.spec.ts
@@ -113,15 +113,15 @@ test("Raw data filtering by rounding datetime to app resolution and retain only 
     stubs: ['router-link']
     }
   )
-  await wrapper.vm.loadData()
+  await (wrapper.vm as any).loadData()
   await wrapper.vm.$nextTick()
-  let vptsAllRows = wrapper.vm.radarVpts
+  let vptsAllRows = (wrapper.vm as any).radarVpts
 
   // Only 30min resolution timestamps should be in the radarVptsobject
-  expect(Object.keys(wrapper.vm.radarVpts).map(x => parseInt(x))).toEqual(expect.arrayContaining(
+  expect(Object.keys((wrapper.vm as any).radarVpts).map(x => parseInt(x))).toEqual(expect.arrayContaining(
     [moment.utc("2020-01-29 10:30").valueOf(), moment.utc("2020-01-29 11:00").valueOf(),
     moment.utc("2020-01-29 11:30").valueOf(), moment.utc("2020-01-29 12:00").valueOf()]));
-  expect(Object.keys(wrapper.vm.radarVpts).map(x => parseInt(x))).toEqual(expect.not.arrayContaining(
+  expect(Object.keys((wrapper.vm as any).radarVpts).map(x => parseInt(x))).toEqual(expect.not.arrayContaining(
     [moment.utc("2020-01-29 10:05").valueOf(), moment.utc("2020-01-29 10:10").valueOf(),
     moment.utc("2020-01-29 10:15").valueOf(), moment.utc("2020-01-29 10:20").valueOf()]));
 
@@ -148,7 +148,7 @@ test("Raw data filtering by rounding datetime to app resolution and retain only 
   }).data as BioRadProfile[];
   ["2020-01-29 10:30:00", "2020-01-29 11:00:00", "2020-01-29 11:30:00"].forEach( timeStamp => {
     let bioradData = integratedProfilesBiorad.filter((x: BioRadProfile) => moment.utc(x.datetime).isSame(moment.utc(timeStamp)))
-    let jsData = wrapper.vm.integratedProfiles.filter((x: VPIEntry) => x.moment.isSame(moment.utc(timeStamp)))
+    let jsData = (wrapper.vm as any).integratedProfiles.filter((x: VPIEntry) => x.moment.isSame(moment.utc(timeStamp)))
     expect(round3decimals(bioradData[0].mtr)).toEqual(round3decimals(jsData[0].integratedProfiles.mtr));
 
   })
@@ -176,15 +176,15 @@ test("Raw data filtering by rounding datetime to app resolution and retain only 
     stubs: ['router-link']
     }
   )
-  await wrapper.vm.loadData()
+  await (wrapper.vm as any).loadData()
   await wrapper.vm.$nextTick()
-  let vptsAllRows = wrapper.vm.radarVpts
+  let vptsAllRows = (wrapper.vm as any).radarVpts
 
   // Only 30min resolution timestamps should be in the radarVptsobject
-  expect(Object.keys(wrapper.vm.radarVpts).map(x => parseInt(x))).toEqual(expect.arrayContaining(
+  expect(Object.keys((wrapper.vm as any).radarVpts).map(x => parseInt(x))).toEqual(expect.arrayContaining(
     [moment.utc("2020-01-29 10:30").valueOf(), moment.utc("2020-01-29 11:00").valueOf(),
     moment.utc("2020-01-29 11:30").valueOf(), moment.utc("2020-01-29 12:00").valueOf()]));
-  expect(Object.keys(wrapper.vm.radarVpts).map(x => parseInt(x))).toEqual(expect.not.arrayContaining(
+  expect(Object.keys((wrapper.vm as any).radarVpts).map(x => parseInt(x))).toEqual(expect.not.arrayContaining(
     [moment.utc("2020-01-29 10:05").valueOf(), moment.utc("2020-01-29 10:10").valueOf(),
     moment.utc("2020-01-29 10:15").valueOf(), moment.utc("2020-01-29 10:20").valueOf()]));
 


### PR DESCRIPTION
The tests were not actually failing, but there were TypeScript errors in the test files.

Those errors were due to a bad inference where the system didn't properly detected the variable and functions of the Home component. I fixed that by:

- providing more explicit return types for computed properties of the `Home` component.
- disabled some TS checks by casting the component to `any`. This is not the most elegant solution but I think it's acceptable in tests. The issue is probably a consequence of my willingness to use TS everywhere at a time where the Vue was far from mature.