### PR TITLE
No data found can be displayed in the VPI chart

### DIFF
--- a/src/components/Home.vue
+++ b/src/components/Home.vue
@@ -118,6 +118,7 @@
               :show-time-as="timeZoneToShow"
               :app-temporal-resolution="appTemporalResolution"
               :mode="VPIChartMode"
+              :loading="filesLoadingCount > 0"
               @mode-changed="vpiModeChanged"
             >
               <template #header>
@@ -243,6 +244,7 @@ export default Vue.extend({
   data: function () {
     return {
       readyForCharts: false,
+      filesLoadingCount: 0,
 
       VPIChartStyle: config.VPIChartStyle,
       VPIChartMode: this.vpiChartModeProp as IntegratedPropertyName,
@@ -640,6 +642,7 @@ export default Vue.extend({
     ): void {
       for (let currentDate of this.getDatesForData(startMoment, endMoment)) {
         const url = helpers.buildVpTsDataUrl(radar, moment(currentDate, "YYYY-MM-DD"));
+        this.filesLoadingCount++;
         axios.get(url).then(response => {
           // Data are floored to resolution of app (`parseVol2birdVpts()`), which can create multiple entries with the same datetime index
           // In this section:
@@ -658,6 +661,8 @@ export default Vue.extend({
           for (const val of dayData) {
             this.storeDataRow(val);
           }
+        }).finally(() => {
+          this.filesLoadingCount--;
         });
       }
     },

--- a/src/components/VPIChart.vue
+++ b/src/components/VPIChart.vue
@@ -194,6 +194,7 @@ export default Vue.extend({
     showTimeAs: String, // "UTC" or a TZ database entry (such as "Europe/Brussels")
     appTemporalResolution: Number,
     mode: String as () => IntegratedPropertyName,
+    loading: Boolean
   },
   data: function () {
     return {
@@ -384,7 +385,7 @@ export default Vue.extend({
     },
     noData: function (): boolean {
       const emptyMaxValue = this.selectedModeObject.yMaxValComputedName === 'maxMTRWithMinimum' ? MinRTRValueDisplay : 0;
-      return this.yMaxVal === emptyMaxValue;
+      return (this.yMaxVal === emptyMaxValue) && !this.loading;
     },
     yMaxVal: function (): number {
       return this[this.selectedModeObject.yMaxValComputedName];

--- a/src/components/VPIChart.vue
+++ b/src/components/VPIChart.vue
@@ -27,7 +27,7 @@
       :height="styleConfig.height"
       class="d-block mx-auto"
     >
-      <text v-if="noData" x="50%" y="50%">No data found</text>
+      <text v-if="noData" x="50%" y="50%">{{ t("No data found") }}</text>
 
       <g :transform="`translate(${margin.left}, ${margin.top})`">
         <!-- X axis -->
@@ -251,6 +251,11 @@ export default Vue.extend({
           en: "VIR: reflected bird surface (cm²) per km²",
           fr: "VIR: surface réfléchie par les oiseaux (cm²) par km²",
           nl: "VIR: gereflecteerde vogeloppervlakte (cm²) per km²"
+        },
+        "No data found": {
+          en: "No data found",
+          fr: "Données introuvables",
+          nl: "Geen data gevonden"
         }
       } as MultilanguageStringContainer,
 

--- a/src/components/VPIChart.vue
+++ b/src/components/VPIChart.vue
@@ -27,6 +27,8 @@
       :height="styleConfig.height"
       class="d-block mx-auto"
     >
+      <text v-if="noData" x="50%" y="50%">No data found</text>
+
       <g :transform="`translate(${margin.left}, ${margin.top})`">
         <!-- X axis -->
         <g :transform="`translate(0, ${innerHeight})`">
@@ -100,7 +102,7 @@
           :d="pathData"
         />
 
-        <daily-lines :days="daysCovered" :height="innerHeight" />
+        <daily-lines v-if="!noData" :days="daysCovered" :height="innerHeight" />
       </g>
     </svg>
   </div>
@@ -120,6 +122,8 @@ import { DayData, VPIEntry, IntegratedPropertyName, LangCode, MultilanguageStrin
 
 import TWEEN from "@tweenjs/tween.js";
 import { UserChoicesStoreModule } from "@/store/UserChoicesStore";
+
+const MinRTRValueDisplay = 50;  // If the maximum MTR is small, we return 50 so a small peak on a very calm day doesn't seem huge on the chart
 
 type NullableNumber = number | null;
 type NullableVPIEntry = VPIEntry | null;
@@ -367,12 +371,15 @@ export default Vue.extend({
       return max || 0;
     },
     maxMTRWithMinimum: function (): number {
-      // If the maximum MTR is small, we return 50 so a small peak on a very calm day doesn't seem huge
-      if (this.maxMTR < 50) {
-        return 50;
+      if (this.maxMTR < MinRTRValueDisplay) {
+        return MinRTRValueDisplay;
       } else {
         return this.maxMTR;
       }
+    },
+    noData: function (): boolean {
+      const emptyMaxValue = this.selectedModeObject.yMaxValComputedName === 'maxMTRWithMinimum' ? MinRTRValueDisplay : 0;
+      return this.yMaxVal === emptyMaxValue;
     },
     yMaxVal: function (): number {
       return this[this.selectedModeObject.yMaxValComputedName];
@@ -421,7 +428,6 @@ export default Vue.extend({
       const path = d3
         .area<VPIEntryForPath>()
         .defined((vpiEntryFP) => {
-          //console.log(vpiEntryFP);
           return !isNaN(vpiEntryFP.sourceVal);
         })
         .x((vpiEntryFP) => {


### PR DESCRIPTION
Implement a solution for #172 

I initially started implementing as described in the issue (showing error in case all the requested data files got 404 errors), but I got a few issues:

- nasty edge cases (if I request data for tomorrow in "radar time" => 2 files requested: today - for the last hour of the day - and tomorrow => since today's file is found, no error is shown but the chart stays empty because we don't have data yet from 11pm)
- unnecessary complex implementation: detecting issue in one component and showing it in another one
- data can be missing for other reasons than error 404: another server error code, empty data files, ...

=> I therefore took a more straightforward way: the first chart shows the error whenever it has no data to show, regardless of the reason. Would that work for you?