### PR TITLE
New settings to show radar code in dropdown

### DIFF
--- a/src/CrowTypes.ts
+++ b/src/CrowTypes.ts
@@ -46,6 +46,7 @@ export interface VPIEntry {
 export interface RadarInterface {
   odimCode: string;
   text: string;  // Location name
+  selectLabel: string // To be displayed in select. Either just the location, or the code and location (depending on configuration)
   country: string;
   latitude: number;
   longitude: number;

--- a/src/components/SiteSelector.vue
+++ b/src/components/SiteSelector.vue
@@ -4,6 +4,7 @@
       id="input-radar"
       :value="selectedRadarCode"
       value-field="odimCode"
+      text-field="selectLabel"
       size="sm"
       :options="availableRadars"
       @change="setSelectedRadarCode"

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,6 +19,7 @@ export default {
     { label: "Français", code: "fr"}
   ] as Language[],
   initialLanguageCode: "en" as LangCode,
+  radarLabelIncludesCode: true,
   availableRadars: [
     {
       label: "Belgium",

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,7 +19,7 @@ export default {
     { label: "Français", code: "fr"}
   ] as Language[],
   initialLanguageCode: "en" as LangCode,
-  radarLabelIncludesCode: true,
+  radarLabelIncludesCode: false,
   availableRadars: [
     {
       label: "Belgium",

--- a/src/store/ConfigStore.ts
+++ b/src/store/ConfigStore.ts
@@ -5,9 +5,27 @@ import store from "./index";
 
 @Module({ dynamic: true, store, name: "conf" })
 export class ConfigStore extends VuexModule {
-  availableRadars: GroupedRadarInterface[] = config.availableRadars;
   availableIntervals: TimeInterval[] = config.availableTimeIntervals;
   availableLanguages: Language[] = config.availableLanguages;
+
+  get availableRadars(): GroupedRadarInterface[] {
+    return config.availableRadars.map(radarGroup => {
+      return {
+        label: radarGroup.label,
+        options: radarGroup.options.map(radar => {
+          let displayLabel = radar.text;
+            if ('radarLabelIncludesCode' in config && config["radarLabelIncludesCode"] === true) {
+              displayLabel = radar.odimCode + " - " + radar.text;
+          }
+
+          return {
+            ...radar, selectLabel: displayLabel
+          }
+        })
+      }
+    
+    });
+  }
 }
 
 export const ConfigStoreModule = getModule(ConfigStore);


### PR DESCRIPTION
This is a fix for #195 

You now can (it is optional and defaults to `false`) add a new entry such as `radarLabelIncludesCode: true` to the config object of `config.ts`.

This will prefix the radar name with the code, as requested in #195.

Hope this helps!

