### PR TITLE
New mechanism to hide some radars from the selection map

### DIFF
--- a/src/CrowTypes.ts
+++ b/src/CrowTypes.ts
@@ -54,6 +54,7 @@ export interface RadarInterface {
   endpoint: string; // URL template, some variables are interpolated. Example: 'https://opendata.meteo.be/ftp/observations/radar/vbird/{odimCode}/{yyyy}/{odimCode}_vpts_{yyyymmdd}.txt'
   vptsFileFormat: VPTSFileFormat;
   heights: number[]; // Data is available at the following heights
+  hideOnMap?: boolean; // If true, the radar will not be displayed on the map
 }
 
 export type VPTSFileFormat = "VOL2BIRD" | "CSV";  // VOL2BIRD: fixed width column. CSV: Follow BioRad's output (see https://github.com/inbo/crow/issues/135)

--- a/src/components/SiteSelectorMap.vue
+++ b/src/components/SiteSelectorMap.vue
@@ -2,7 +2,7 @@
   <svg class="d-none d-lg-block mt-3 mx-auto" :width="svgWidth" :height="svgHeight">
     <g>
       <path id="country" :d="countryPath" stroke="#000" stroke-width="1" />
-      <circle v-for="radar in radars" :id="'circle-radar-' + radar.odimCode" :key="radar.odimCode" :class="getRadarExtraClass(radar)" r="5px" :cx="projectRadar(radar)[0]" :cy="projectRadar(radar)[1]" @click="$emit('click-circle', radar.odimCode)">
+      <circle v-for="radar in visibleRadars" :id="'circle-radar-' + radar.odimCode" :key="radar.odimCode" :class="getRadarExtraClass(radar)" r="5px" :cx="projectRadar(radar)[0]" :cy="projectRadar(radar)[1]" @click="$emit('click-circle', radar.odimCode)">
         <b-popover :target="'circle-radar-' + radar.odimCode" triggers="hover">
           {{ radar.displayLabel }}
         </b-popover>
@@ -44,7 +44,7 @@ export default Vue.extend({
     radarsFeatures: function (): d3.ExtendedFeatureCollection {
       let geojson = { type: "FeatureCollection", features: [] } as d3.ExtendedFeatureCollection
 
-      this.radars.forEach(r => {
+      this.visibleRadars.forEach(r => {
         let feature = {
           "type": "Feature",
           "geometry": {
@@ -59,14 +59,15 @@ export default Vue.extend({
 
       return geojson
     },
-    radars: function (): RadarInterface[] {
+    visibleRadars: function (): RadarInterface[] {
       // Flat array of radars based on the "sites" prop
       let r: RadarInterface[] = []
       this.sites.forEach(e => {
         r = r.concat(e.options)
       })
 
-      return r;
+      // Filter out radars that have a hideOnMap property set to true
+      return r.filter(r => r.hideOnMap !== true);
     },
     projection: function (): d3.GeoProjection {
       return d3.geoMercator()

--- a/src/config.ts
+++ b/src/config.ts
@@ -27,7 +27,7 @@ export default {
         { odimCode: "behel", text: "Helchteren", latitude: 51.069199, longitude: 5.406138, timezone: "Europe/Brussels", endpoint: meteoBeUrlTemplate, heights: availableHeights, vptsFileFormat: 'VOL2BIRD' },
         { odimCode: "bejab", text: "Jabbeke", latitude: 51.1919, longitude: 3.0641, timezone: "Europe/Brussels", endpoint: meteoBeUrlTemplate, heights: availableHeights, vptsFileFormat: 'VOL2BIRD' },
         { odimCode: "bewid", text: "Wideumont", latitude: 49.9135, longitude: 5.5044, timezone: "Europe/Brussels", endpoint: meteoBeUrlTemplate, heights: availableHeights, vptsFileFormat: 'VOL2BIRD' },
-        { odimCode: "bezav", text: "Zaventem", latitude: 50.9054, longitude: 4.4579, timezone: "Europe/Brussels", endpoint: meteoBeUrlTemplate, heights: availableHeights, vptsFileFormat: 'VOL2BIRD' },
+        { odimCode: "bezav", text: "Zaventem", latitude: 50.9054, longitude: 4.4579, timezone: "Europe/Brussels", endpoint: meteoBeUrlTemplate, heights: availableHeights, vptsFileFormat: 'VOL2BIRD', hideOnMap: false },
       ]
     },
     {


### PR DESCRIPTION
This solves the issue described at https://github.com/inbo/crow/issues/201 by adding a new optional option (`hideOnMap`) in the radar configuration.

You can see an example with the "bezav" configuration below (I set it to false here so it's not hidden on INBO CROW site).

I guess the next step is to sync the `enram/crow` repo on this one, and add `hideOnMap` entries for the deprecated radars.

Don't hesitate to ping me if you need help to do it, or if something doesn't work as expected!

Cheers