### PR TITLE
Fix npm scripts for Node 17+ (OpenSSL legacy provider)

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "serve": "vue-cli-service serve",
-    "build": "vue-cli-service build",
+    "serve": "NODE_OPTIONS=--openssl-legacy-provider vue-cli-service serve",
+    "build": "NODE_OPTIONS=--openssl-legacy-provider vue-cli-service build",
     "test:unit": "vue-cli-service test:unit",
     "lint": "vue-cli-service lint"
   },


### PR DESCRIPTION
## Summary

- `npm run serve` / `npm run build` were failing on Node 17+ with `error:0308010C:digital envelope routines::unsupported`.
- Root cause: webpack 4 (via `vue-cli-service`) uses an MD4 hash that OpenSSL 3 no longer exposes by default.
- Workaround: prepend `NODE_OPTIONS=--openssl-legacy-provider` to the `serve` and `build` scripts so they work out of the box on modern Node.

This is a band-aid - the real fix is migrating off vue-cli/webpack 4, but that's a much larger change.

## Test plan

- [ ] `npm run serve` starts the dev server without the OpenSSL error
- [ ] `npm run build` completes successfully